### PR TITLE
Update Faq.md

### DIFF
--- a/Faq.md
+++ b/Faq.md
@@ -55,7 +55,7 @@ Is recommended reading the [Getting Started](Getting-Started.md) section. Basica
 
 The Xamarin.Forms GTK backend makes use of [webkit-sharp](https://github.com/mono/webkit-sharp). If you do not have it installed, you must install `libwebkit-dev package`:
 
-    sudo apt-get install libwebkit-dev
+    sudo apt-get install libwebkitgtk-dev
 
 **I have tried the backend, in Linux I have problems to perform http requests. What can I do?**
 


### PR DESCRIPTION
```sudo apt-get install libwebkit-dev``` --> ```sudo apt-get install libwebkitgtk-dev```

because:
```
Package libwebkit-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libwebkitgtk-dev libjavascriptcoregtk-1.0-dev
```